### PR TITLE
Added OnBeforeBuildBatch and OnAfterBuildBatch

### DIFF
--- a/GTFO-API/API/LevelAPI.cs
+++ b/GTFO-API/API/LevelAPI.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using GameData;
 using GTFO.API.Attributes;
 using GTFO.API.Resources;
+using LevelGeneration;
 using SNetwork;
 
 namespace GTFO.API
@@ -83,6 +80,16 @@ namespace GTFO.API
         /// </summary>
         public static event Action OnLevelCleanup;
 
+        /// <summary>
+        /// Invoked when LevelGeneration Job Batch has Started
+        /// </summary>
+        public static event Action<LG_Factory.BatchName> OnBeforeBuildBatch;
+
+        /// <summary>
+        /// Invoked when LevelGeneration Job Batch has Finished
+        /// </summary>
+        public static event Action<LG_Factory.BatchName> OnAfterBuildBatch;
+
         internal static void ExpeditionUpdated(pActiveExpedition activeExp, ExpeditionInTierData expData)
         {
             OnLevelDataUpdated?.Invoke(ActiveExpedition.CreateFrom(activeExp), expData);
@@ -101,6 +108,8 @@ namespace GTFO.API
         internal static void BuildDone() => OnBuildDone?.Invoke();
         internal static void EnterLevel() => OnEnterLevel?.Invoke();
         internal static void LevelCleanup() => OnLevelCleanup?.Invoke();
+        internal static void BeforeBuildBatch(LG_Factory.BatchName batchName) => OnBeforeBuildBatch?.Invoke(batchName);
+        internal static void AfterBuildBatch(LG_Factory.BatchName batchName) => OnAfterBuildBatch?.Invoke(batchName);
     }
 
     /// <summary>

--- a/GTFO-API/Patches/LevelGen_Patches.cs
+++ b/GTFO-API/Patches/LevelGen_Patches.cs
@@ -1,0 +1,28 @@
+﻿using HarmonyLib;
+using LevelGeneration;
+
+namespace GTFO.API.Patches
+{
+    [HarmonyPatch(typeof(LG_Factory))]
+    internal static class LevelGen_Patches
+    {
+        [HarmonyPrefix]
+        [HarmonyWrapSafe]
+        [HarmonyPatch(nameof(LG_Factory.NextBatch))]
+        private static void Pre_Batch(LG_Factory __instance)
+        {
+            if (__instance.m_batchStep > -1)
+            {
+                LevelAPI.AfterBuildBatch(__instance.m_currentBatchName);
+            }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyWrapSafe]
+        [HarmonyPatch(nameof(LG_Factory.NextBatch))]
+        private static void Post_Batch(LG_Factory __instance)
+        {
+            LevelAPI.BeforeBuildBatch(__instance.m_currentBatchName);
+        }
+    }
+}


### PR DESCRIPTION
Event API for Build Batch has added to handle some level gen features that only safe to do in specific batch
IE) SecurityDoorTerminal requires to spawn after `LG_Factory.BatchName.FunctionMarkerFallback` to work without any issue

```cs
LevelAPI.OnBeforeBuildBatch += (LG_Factory.BatchName batch) => {};
LevelAPI.OnAfterBuildBatch += (LG_Factory.BatchName batch) => {};
```