### PR TITLE
Adding Fail-safety to API events

### DIFF
--- a/GTFO-API/API/AssetAPI.cs
+++ b/GTFO-API/API/AssetAPI.cs
@@ -7,6 +7,7 @@ using BepInEx;
 using GTFO.API.Attributes;
 using GTFO.API.Impl;
 using GTFO.API.Resources;
+using GTFO.API.Utilities;
 using UnityEngine;
 
 namespace GTFO.API
@@ -194,10 +195,10 @@ namespace GTFO.API
             {
                 APIStatus.CreateApi<AssetAPI_Impl>(nameof(APIStatus.Asset));
             }
-            OnStartupAssetsLoaded?.Invoke();
+            SafeInvoke.Invoke(OnStartupAssetsLoaded);
         }
 
-        internal static void InvokeImplReady() => OnImplReady?.Invoke();
+        internal static void InvokeImplReady() => SafeInvoke.Invoke(OnImplReady);
 
         internal static void Setup()
         {
@@ -212,7 +213,7 @@ namespace GTFO.API
             bool anyLoaded = LoadAssetBundles(assetBundleDir);
             anyLoaded |= LoadAssetBundles(assetBundlesDirOld, outdated: true);
             if (anyLoaded)
-                OnAssetBundlesLoaded?.Invoke();
+                SafeInvoke.Invoke(OnAssetBundlesLoaded);
         }
 
         private static bool LoadAssetBundles(string assetBundlesDir, bool outdated = false)

--- a/GTFO-API/API/EventAPI.cs
+++ b/GTFO-API/API/EventAPI.cs
@@ -3,6 +3,7 @@ using AssetShards;
 using Globals;
 using GTFO.API.Attributes;
 using GTFO.API.Resources;
+using GTFO.API.Utilities;
 
 namespace GTFO.API
 {
@@ -36,8 +37,8 @@ namespace GTFO.API
             RundownManager.add_OnExpeditionGameplayStarted((Action)ExpeditionStarted);
         }
 
-        private static void ManagersSetup() => OnManagersSetup?.Invoke();
-        private static void ExpeditionStarted() => OnExpeditionStarted?.Invoke();
-        private static void AssetsLoaded() => OnAssetsLoaded?.Invoke();
+        private static void ManagersSetup() => SafeInvoke.Invoke(OnManagersSetup);
+        private static void ExpeditionStarted() => SafeInvoke.Invoke(OnExpeditionStarted);
+        private static void AssetsLoaded() => SafeInvoke.Invoke(OnAssetsLoaded);
     }
 }

--- a/GTFO-API/API/GameDataAPI.cs
+++ b/GTFO-API/API/GameDataAPI.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using GTFO.API.Attributes;
 using GTFO.API.Resources;
+using GTFO.API.Utilities;
 
 namespace GTFO.API
 {
@@ -23,6 +24,6 @@ namespace GTFO.API
         /// </summary>
         public static event Action OnGameDataInitialized;
 
-        internal static void InvokeGameDataInit() => OnGameDataInitialized?.Invoke();
+        internal static void InvokeGameDataInit() => SafeInvoke.Invoke(OnGameDataInitialized);
     }
 }

--- a/GTFO-API/API/LevelAPI.cs
+++ b/GTFO-API/API/LevelAPI.cs
@@ -2,6 +2,7 @@
 using GameData;
 using GTFO.API.Attributes;
 using GTFO.API.Resources;
+using GTFO.API.Utilities;
 using LevelGeneration;
 using SNetwork;
 
@@ -104,12 +105,12 @@ namespace GTFO.API
                 s_LatestExpIndex = index;
             }
         }
-        internal static void BuildStart() => OnBuildStart?.Invoke();
-        internal static void BuildDone() => OnBuildDone?.Invoke();
-        internal static void EnterLevel() => OnEnterLevel?.Invoke();
-        internal static void LevelCleanup() => OnLevelCleanup?.Invoke();
-        internal static void BeforeBuildBatch(LG_Factory.BatchName batchName) => OnBeforeBuildBatch?.Invoke(batchName);
-        internal static void AfterBuildBatch(LG_Factory.BatchName batchName) => OnAfterBuildBatch?.Invoke(batchName);
+        internal static void BuildStart() => SafeInvoke.Invoke(OnBuildStart);
+        internal static void BuildDone() => SafeInvoke.Invoke(OnBuildDone);
+        internal static void EnterLevel() => SafeInvoke.Invoke(OnEnterLevel);
+        internal static void LevelCleanup() => SafeInvoke.Invoke(OnLevelCleanup);
+        internal static void BeforeBuildBatch(LG_Factory.BatchName batchName) => SafeInvoke.Invoke(OnBeforeBuildBatch, batchName);
+        internal static void AfterBuildBatch(LG_Factory.BatchName batchName) => SafeInvoke.Invoke(OnAfterBuildBatch, batchName);
     }
 
     /// <summary>

--- a/GTFO-API/API/LocalizationAPI.cs
+++ b/GTFO-API/API/LocalizationAPI.cs
@@ -1,16 +1,17 @@
 ﻿using System;
-using System.Resources;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Globalization;
+using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using GameData;
 using GTFO.API.Attributes;
-using Localization;
 using GTFO.API.Resources;
-using System.Runtime.CompilerServices;
+using GTFO.API.Utilities;
+using Localization;
 
 #nullable enable
 namespace GTFO.API;
@@ -61,7 +62,7 @@ public static partial class LocalizationAPI
 
     internal static void LanguageChanged()
     {
-        OnLanguageChange?.Invoke();
+        SafeInvoke.Invoke(OnLanguageChange);
     }
 
     /// <summary>

--- a/GTFO-API/API/SoundBankAPI.cs
+++ b/GTFO-API/API/SoundBankAPI.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using BepInEx;
 using GTFO.API.Attributes;
 using GTFO.API.Resources;
+using GTFO.API.Utilities;
 using HarmonyLib;
 
 namespace GTFO.API
@@ -39,7 +40,7 @@ namespace GTFO.API
             soundbanksToLoad.Do(LoadBank);
 
             if (soundbanksToLoad.Any())
-                OnSoundBanksLoaded?.Invoke();
+                SafeInvoke.Invoke(OnSoundBanksLoaded);
         }
 
         private static unsafe void LoadBank(FileInfo file)

--- a/GTFO-API/Utilities/SafeInvoke.cs
+++ b/GTFO-API/Utilities/SafeInvoke.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Linq;
+
+namespace GTFO.API.Utilities
+{
+    /// <summary>
+    /// Utility Class for Safely Invoke Delegates one-by-one with try-catching
+    /// </summary>
+    public static class SafeInvoke
+    {
+        /// <summary>
+        /// Safely Invoke Action one-by-one with Try-Catch
+        /// </summary>
+        /// <param name="actionToInvoke">Action to Invoke</param>
+        public static void Invoke(Action actionToInvoke)
+        {
+            if (actionToInvoke == null)
+                return;
+
+            foreach (var handler in actionToInvoke.GetInvocationList().Cast<Action>())
+            {
+                try
+                {
+                    handler();
+                }
+                catch (Exception e)
+                {
+                    APILogger.Error("GTFO-API", $"Exception occured while invoking events!\n{e}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Safely Invoke Action one-by-one with Try-Catch
+        /// </summary>
+        /// <param name="actionToInvoke">Action to Invoke</param>
+        /// <param name="arg0">Argument to pass (Index 0)</param>
+        public static void Invoke<T>(Action<T> actionToInvoke, T arg0)
+        {
+            if (actionToInvoke == null)
+                return;
+
+            foreach (var handler in actionToInvoke.GetInvocationList().Cast<Action<T>>())
+            {
+                try
+                {
+                    handler(arg0);
+                }
+                catch (Exception e)
+                {
+                    APILogger.Error("GTFO-API", $"Exception occured while invoking events!\n{e}");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
In current behaviour of API Event is:
- If some random plugin throws exception in API Events
- Every other plugin that registered for event later would not be invoked

And this PR Changes it to:
- If some random plugin throws exception in API Events
- Catch it and continue to invoke rest

Also revealing `SafeInvoke` Utility class for use